### PR TITLE
Draft copas support

### DIFF
--- a/mqtt/client.lua
+++ b/mqtt/client.lua
@@ -938,7 +938,7 @@ function client_mt:_ioloop_iteration()
 						self.reconnect_timer_start = nil
 						self:start_connecting()
 					else
-						loop:can_sleep()
+						if loop then loop:can_sleep() end
 					end
 				else
 					self.reconnect_timer_start = os_time()
@@ -946,7 +946,7 @@ function client_mt:_ioloop_iteration()
 			end
 		else
 			-- finish working with client
-			loop:remove(self)
+			if loop then loop:remove(self) end
 		end
 	end
 end

--- a/mqtt/client.lua
+++ b/mqtt/client.lua
@@ -908,7 +908,12 @@ function client_mt:_ioloop_iteration()
 	if conn then
 		-- network connection opened
 		-- perform packet receiving using ioloop receive function
-		local ok, err = self:_io_iteration(ioloop_recv)
+		local ok, err
+		if loop then
+			ok, err = self:_io_iteration(ioloop_recv)
+		else
+			ok, err = self:_sync_iteration()
+		end
 
 		if ok then
 			-- send PINGREQ if keep_alive interval is reached

--- a/mqtt/luasocket-copas.lua
+++ b/mqtt/luasocket-copas.lua
@@ -1,0 +1,47 @@
+-- DOC: http://w3.impa.br/~diego/software/luasocket/tcp.html
+
+-- module table
+local luasocket = {}
+
+local socket = require("socket")
+local copas = require("copas")
+
+-- Open network connection to .host and .port in conn table
+-- Store opened socket to conn table
+-- Returns true on success, or false and error text on failure
+function luasocket.connect(conn)
+	local sock, err = socket.connect(conn.host, conn.port)
+	if not sock then
+		return false, "socket.connect failed: "..err
+	end
+	conn.sock = sock
+	return true
+end
+
+-- Shutdown network connection
+function luasocket.shutdown(conn)
+	conn.sock:shutdown()
+end
+
+-- Send data to network connection
+function luasocket.send(conn, data, i, j)
+	local ok, err = copas.send(conn.sock, data, i, j)
+	return ok, err
+end
+
+-- Receive given amount of data from network connection
+function luasocket.receive(conn, size)
+	local ok, err = copas.receive(conn.sock, size)
+	return ok, err
+end
+
+-- Set connection's socket to non-blocking mode and set a timeout for it
+function luasocket.settimeout(conn, timeout)
+	conn.timeout = timeout
+	conn.sock:settimeout(0)
+end
+
+-- export module table
+return luasocket
+
+-- vim: ts=4 sts=4 sw=4 noet ft=lua


### PR DESCRIPTION
Proposed changes allow for the following without busy loops:

```lua
  -- client
  local client = mqtt.client {
    connector = require("mqtt.luasocket-copas"),
    ...
  }

  -- client setup
  ...

  -- client thread
  copas.addthread(function()
    while true do
      client:_ioloop_iteration()
    end
  end)

  -- custom logic
  copas.addthread(function()
    while true do
      copas.sleep(1)
      print("TICK!")
    end
  end)

  copas.loop()
```
