### PR TITLE
Use git+https protocol instead of git

### DIFF
--- a/luamqtt-3.4.2-2.rockspec
+++ b/luamqtt-3.4.2-2.rockspec
@@ -1,7 +1,7 @@
 package = "luamqtt"
 version = "3.4.2-2"
 source = {
-	url = "git://github.com/xHasKx/luamqtt",
+	url = "git+https://github.com/xHasKx/luamqtt.git",
 	tag = "v3.4.2",
 }
 description = {

--- a/luamqtt-3.4.2-3.rockspec
+++ b/luamqtt-3.4.2-3.rockspec
@@ -1,5 +1,5 @@
 package = "luamqtt"
-version = "3.4.2-2"
+version = "3.4.2-3"
 source = {
 	url = "git+https://github.com/xHasKx/luamqtt.git",
 	tag = "v3.4.2",


### PR DESCRIPTION
The installation with luarocks doesn't work anymore because the git url is depreciated: https://github.blog/2021-09-01-improving-git-protocol-security-github/.

```
$ sudo luarocks install luamqtt
Installing https://luarocks.org/luamqtt-3.4.2-2.rockspec
Klone nach 'luamqtt' ...
fatal: Fehler am anderen Ende: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

Error: Failed cloning git repository.
```