### PR TITLE
Fix MQTT v5.0 "beyond size" error in PUBACK parsing

### DIFF
--- a/mqtt/protocol5.lua
+++ b/mqtt/protocol5.lua
@@ -980,24 +980,31 @@ local function parse_packet_puback(ptype, flags, input)
 		return false, packet_type[ptype]..": unexpected flags value: "..flags
 	end
 	local read_data = input.read_func
+
 	-- DOC: 3.4.2 PUBACK Variable Header
+	-- Bytes 1 & 2: Packet Identifier
 	local packet_id, err = parse_uint16(read_data)
 	if not packet_id then
 		return false, packet_type[ptype]..": failed to parse packet_id: "..err
 	end
 	local packet = setmetatable({type=ptype, packet_id=packet_id, rc=0, properties={}, user_properties={}}, packet_mt)
+	-- If Remaining Length > 2, we have at least a Reason Code
 	if input.available > 0 then
-		-- DOC: 3.4.2.1 PUBACK Reason Code
+		-- DOC: 3.4.2.1 PUBACK Reason Code (Byte 3)
 		local rc, ok
 		rc, err = parse_uint8(read_data)
 		if not rc then
 			return false, packet_type[ptype]..": failed to parse rc: "..err
 		end
 		packet.rc = rc
-		-- DOC: 3.4.2.2 PUBACK Properties
-		ok, err = parse_properties(ptype, read_data, input, packet)
-		if not ok then
-			return false, packet_type[ptype]..": failed to parse packet properties: "..err
+
+		-- DOC: 3.4.2.2.1 If Remaining Length > 3, we have a Property Length field (Byte 4)
+		if input.available > 0 then
+			-- DOC: 3.4.2.2 PUBACK Properties
+			ok, err = parse_properties(ptype, read_data, input, packet)
+			if not ok then
+				return false, packet_type[ptype]..": failed to parse packet properties: "..err
+			end
 		end
 	end
 	return packet


### PR DESCRIPTION
This PR addresses a protocol parsing error in the MQTT v5.0 implementation where certain PUBACK packets would trigger a "beyond size" error and a subsequent connection drop.

The issue was identified during a late-night debugging session involving my MQTT broker that omit the Optional Properties section in 3-byte packets (Packet ID + Reason Code).

### Technical Context
Per MQTT v5.0 Specification (Section 3.4.2), the Variable Header for PUBACK is flexible in length:

- **Length 2**: Packet Identifier only.
- **Length 3**: Packet Identifier + Reason Code.
- **Length 4+**: Packet Identifier + Reason Code + Property Length indicator + Properties.

Specifically, Section 3.4.2.2.1 (Property Length) states:

_The length of the Properties in the PUBACK packet Variable Header encoded as a Variable Byte Integer. **If the Remaining Length is less than 4 there is no Property Length and the value of 0 is used.**_

The existing logic correctly checked `input.available > 0` before parsing the Reason Code. However, it failed to perform a subsequent check before calling `parse_properties`. If a broker sends exactly 3 bytes, the parser attempts to read a "Property Length" byte that does not exist according to the spec, resulting in a fatal buffer error.

### Scope of Changes

- **What this covers**: This adds a nested input.available > 0 check in parse_packet_puback to ensure data exists for the Properties section before attempting to read the Property Length.
- **What this does _not_ cover**: This does **not** cover other packet types. This "Optional Reason Code + Optional Properties" pattern also exists in `pubrec`, `pubrel`, `pubcomp`, and `unsuback`. Due to time constraints, I am only submitting the fix for `puback` at this time as it was the specific blocker for my environment. I likely will not have the bandwidth to address the others in the near future; I invite any interested contributors to apply this same logic to the remaining functions in `protocol5.lua`.

### Repository & History Strategy
I am raising this PR in both [xHasKx/luamqtt](https://github.com/xHasKx/luamqtt) and [Tieske/luamqtt](https://github.com/Tieske/luamqtt/).

To maintain structural integrity across repository boundaries:

- The patch was applied to a commit derived from the common fork point (determined via git merge-base).
- This commit was then merged into the respective "live" branches of both repositories.
- This ensures that if the forks are ever merged back into a single upstream, the history remains clean and the changes integrate without conflict.

**Cross-Reference**: I will add a link to the corresponding PR in the comments once both have been successfully created.