### PR TITLE
Lua 5.5 compatibility

### DIFF
--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -11,7 +11,8 @@ jobs:
         run: sudo apt-get install -y lua-check && cd "${{ github.workspace }}" && ./tests/run-luacheck.sh -q
 
       - name: install hererocks to build any lua version
-        run: sudo apt-get install -y libreadline-dev unzip curl && pip install hererocks
+        # NOTE: hererocks from PyPI (0.25.1) does not support Lua 5.5 yet, installing from git
+        run: sudo apt-get install -y libreadline-dev unzip curl && pip install git+https://github.com/luarocks/hererocks
 
       - name: run tests and collect code coverage
         run: cd "${{ github.workspace }}" && COVERAGE=1 ./tests/run-for-all-lua-versions.sh download

--- a/luamqtt-scm-1.rockspec
+++ b/luamqtt-scm-1.rockspec
@@ -22,7 +22,7 @@ No C-dependencies.
 	license = "MIT",
 }
 dependencies = {
-	"lua >= 5.1, <= 5.4",
+	"lua >= 5.1, <= 5.5",
 	"luasocket >= 3.0rc1-2",
 }
 build = {

--- a/mqtt/tools.lua
+++ b/mqtt/tools.lua
@@ -76,6 +76,7 @@ function tools.extract_hex(str)
 	-- iterate through lines
 	local n = 0
 	for line in str:gmatch("[^\n]+") do
+		local line = line
 		n = n + 1
 		-- find a comment start
 		local comment_begin = line:find("--", 1, true)

--- a/mqtt/tools.lua
+++ b/mqtt/tools.lua
@@ -75,8 +75,9 @@ function tools.extract_hex(str)
 	local res = {}
 	-- iterate through lines
 	local n = 0
-	for line in str:gmatch("[^\n]+") do
-		local line = line
+	-- NOTE: in lua 5.5 the loop variable is read-only, so making a local copy to modify it below
+	for raw_line in str:gmatch("[^\n]+") do
+		local line = raw_line
 		n = n + 1
 		-- find a comment start
 		local comment_begin = line:find("--", 1, true)

--- a/tests/run-for-all-lua-versions.sh
+++ b/tests/run-for-all-lua-versions.sh
@@ -8,7 +8,7 @@ set -e
 ROOT="local/hererocks"
 mkdir -p $ROOT
 
-for ver in -l5.1 -l5.2 -l5.3 -l5.4 -j2.0 -j2.1; do
+for ver in -l5.1 -l5.2 -l5.3 -l5.4 -l5.5 -j2.0 -j2.1; do
 	env="$ROOT/v$ver"
 
 	deps=0


### PR DESCRIPTION
updated SCM rock as well as the necessary change (for loop variables are now readonly).
with this change, the examples/simple.lua runs as expected.