### PR TITLE
Add cqueues Connector 

### DIFF
--- a/mqtt/cqueues.lua
+++ b/mqtt/cqueues.lua
@@ -27,7 +27,7 @@ function cq_socket.send(conn, data, i, j)
 	if not j then
 		j = #data
 	end
-	
+
 	local ok, err = conn.sock:send(data, i, j)
 	-- print("    luasocket.send:", ok, err, require("mqtt.tools").hex(data))
 	return ok, err
@@ -35,13 +35,7 @@ end
 
 -- Receive given amount of data from network connection
 function cq_socket.receive(conn, size)
-	local ok, err = conn.sock:read(size)
-	 --if ok then
-	 	--print("    cqueues.receive:", size, require("mqtt.tools").hex(ok))
-	 --elseif err ~= "timeout" then
-	 	--print("    cqueues.receive:", ok, err)
-	 --end
-	return ok, err
+	return conn.sock:read(size)
 end
 
 -- Set connection's socket to non-blocking mode and set a timeout for it

--- a/mqtt/cqueues.lua
+++ b/mqtt/cqueues.lua
@@ -1,4 +1,4 @@
--- DOC: http://w3.impa.br/~diego/software/luasocket/tcp.html
+-- DOC: https://25thandclement.com/~william/projects/cqueues.html
 
 -- module table
 local cq_socket = {}
@@ -28,9 +28,7 @@ function cq_socket.send(conn, data, i, j)
 		j = #data
 	end
 
-	local ok, err = conn.sock:send(data, i, j)
-	-- print("    luasocket.send:", ok, err, require("mqtt.tools").hex(data))
-	return ok, err
+	return conn.sock:send(data, i, j)
 end
 
 -- Receive given amount of data from network connection

--- a/mqtt/cqueues.lua
+++ b/mqtt/cqueues.lua
@@ -1,0 +1,56 @@
+-- DOC: http://w3.impa.br/~diego/software/luasocket/tcp.html
+
+-- module table
+local cq_socket = {}
+
+local socket = require("cqueues.socket")
+
+-- Open network connection to .host and .port in conn table
+-- Store opened socket to conn table
+-- Returns true on success, or false and error text on failure
+function cq_socket.connect(conn)
+	local sock, err = socket.connect(conn.host, conn.port)
+	if not sock then
+		return false, "cqueues.socket.connect failed: "..err
+	end
+	conn.sock = sock
+	return true
+end
+
+-- Shutdown network connection
+function cq_socket.shutdown(conn)
+	conn.sock:shutdown()
+end
+
+-- Send data to network connection
+function cq_socket.send(conn, data, i, j)
+	if not j then
+		j = #data
+	end
+	
+	local ok, err = conn.sock:send(data, i, j)
+	-- print("    luasocket.send:", ok, err, require("mqtt.tools").hex(data))
+	return ok, err
+end
+
+-- Receive given amount of data from network connection
+function cq_socket.receive(conn, size)
+	local ok, err = conn.sock:read(size)
+	 --if ok then
+	 	--print("    cqueues.receive:", size, require("mqtt.tools").hex(ok))
+	 --elseif err ~= "timeout" then
+	 	--print("    cqueues.receive:", ok, err)
+	 --end
+	return ok, err
+end
+
+-- Set connection's socket to non-blocking mode and set a timeout for it
+function cq_socket.settimeout(conn, timeout)
+	conn.timeout = timeout
+	conn.sock:settimeout(timeout, "t")
+end
+
+-- export module table
+return cq_socket
+
+-- vim: ts=4 sts=4 sw=4 noet ft=lua

--- a/tests/spec/mqtt-client.lua
+++ b/tests/spec/mqtt-client.lua
@@ -577,4 +577,76 @@ describe("#copas connector", function()
 	end)
 end)
 
+
+describe("#cqueues connector", function()
+	local mqtt = require("mqtt")
+	--local copas = require("copas")
+	local cqueues = require("cqueues")
+	local cq = cqueues.new()
+	local prefix = "luamqtt/" .. tostring(math.floor(math.random()*1e13))
+
+	it("test", function()
+		-- NOTE: more about flespi tokens:
+		-- https://flespi.com/kb/tokens-access-keys-to-flespi-platform
+		local flespi_token = "stPwSVV73Eqw5LSv0iMXbc4EguS7JyuZR9lxU5uLxI5tiNM8ToTVqNpu85pFtJv9"
+
+		local client = mqtt.client{
+			uri = "mqtt.flespi.io",
+			clean = true,
+			username = flespi_token,
+			version = mqtt.v50,
+
+			connector = require("mqtt.cqueues"),
+		}
+
+		client:on{
+			connect = function()
+				-- print("client connected")
+				assert(client:subscribe{topic=prefix.."/cqueues", qos=1, callback=function()
+					-- print("subscribed")
+					cqueues.sleep(2)
+					assert(client:publish{
+						topic = prefix.."/cqueues",
+						payload = "cqueues test",
+						qos = 1,
+					})
+				end})
+			end,
+
+			message = function(msg)
+				assert(client:acknowledge(msg))
+				-- print("received", msg)
+				if msg.topic == prefix.."/cqueues" and msg.payload == "cqueues test" then
+					-- print("disconnect")
+					assert(client:disconnect())
+				end
+			end
+		}
+
+		local ticks = 0
+		local mqtt_finished = false
+
+		--copas.addthread(function()
+		cq:wrap(function()
+			mqtt.run_sync(client)
+			mqtt_finished = true
+			assert.is_true(ticks > 1, "expecting mqtt client run takes at least one tick")
+		end)
+
+		--copas.addthread(function()
+		cq:wrap(function()
+			for _ = 1, 3 do
+				--copas.sleep(1)
+				cqueues.sleep(1)
+				ticks = ticks + 1
+			end
+		end)
+
+		--copas.loop()
+		assert(cq:loop())
+
+		assert.is_true(mqtt_finished, "expecting mqtt client to finish its work")
+		assert.is_true(ticks == 3, "expecting 3 ticks")
+	end)
+end)
 -- vim: ts=4 sts=4 sw=4 noet ft=lua


### PR DESCRIPTION
This pull request adds a connector for the cqueues module ( see: https://25thandclement.com/~william/projects/cqueues.html ), which has overlapping functionality with Copas/LuaSocket.

Nothing wrong with Copas/LuaSocket; but including both into an existing cqueues-native program to get MQTT support is a bit painful :)